### PR TITLE
Prefix module names to avoid name conflicts 

### DIFF
--- a/src/effi.app.src
+++ b/src/effi.app.src
@@ -3,7 +3,7 @@
   {description, "Erlang Foreign Function Interface"},
   {vsn, "0.1.1-snapshot"},
   {modules, [
-             effi, effi_interact, effi_script, bash, python, r
+             effi, effi_interact, effi_script, effi_bash, effi_python, effi_r
             ]},
   {registered, []},
   {applications, [

--- a/src/effi.app.src
+++ b/src/effi.app.src
@@ -3,7 +3,7 @@
   {description, "Erlang Foreign Function Interface"},
   {vsn, "0.1.1-snapshot"},
   {modules, [
-             effi, effi_interact, effi_script, effi_bash, effi_python, effi_r
+             effi, effi_interact, effi_script, effi_bash, effi_python, effi_r, effi_perl, lib_refactor
             ]},
   {registered, []},
   {applications, [

--- a/src/effi_bash.erl
+++ b/src/effi_bash.erl
@@ -19,7 +19,7 @@
 %% @author Jörgen Brandt <brandjoe@hu-berlin.de>
 
 
--module( r ).
+-module( effi_bash ).
 -author( "Jorgen Brandt <brandjoe@hu-berlin.de>" ).
 -vsn( "0.1.1-snapshot" ).
 
@@ -39,7 +39,7 @@
 %% Callback functions
 %% ------------------------------------------------------------
 
-libpath( Path ) -> [".libPaths(\"", Path, "\")"].
+libpath( _Path ) -> error( unsupported ).
 
 %% ffi_type/0
 %
@@ -48,17 +48,16 @@ ffi_type() -> effi_interact.
 
 %% interpreter/0
 %
-interpreter() -> "Rscript --vanilla -".
+interpreter() -> "bash".
 
 
 %% prefix/0
-%
-prefix() -> "".
+prefix() -> "set -eu -o pipefail".
 
 
 %% suffix/0
 %
-suffix() -> "q()".
+suffix() -> "exit".
 
 
 %% assignment/3
@@ -67,19 +66,17 @@ assignment( ParamName, false, [Value] ) ->
   [ParamName, $=, quote( Value ), $\n];
 
 assignment( ParamName, true, ValueList ) ->
-  [ParamName, "=c(", string:join( [quote( Value ) || Value <- ValueList], "," ), ")\n"].
+  [ParamName, "=(", string:join( [quote( Value ) || Value <- ValueList], " " ), ")\n"].
 
 
 %% dismissal/2
 %
 dismissal( OutName, false ) ->
-  ["cat(\"", ?MSG, "#{\\\"", OutName, "\\\"=>[{str,\\\"\",", OutName,
-   ",\"\\\"}]}.\\n\",sep=\"\")\n"];
+  ["echo \"", ?MSG, "#{\\\"", OutName, "\\\"=>[{str,\\\"$", OutName, "\\\"}]}.\"\n"];
 
 dismissal( OutName, true ) ->
-  ["cat(\"", ?MSG, "#{\\\"", OutName,
-   "\\\"=>[\",Reduce(function(x,y)paste(x,y,sep=\",\"),Map(function(x)paste(\"{str,\\\"\",x,\"\\\"}\",sep=\"\"),",
-   OutName, ")),\"]}.\\n\",sep=\"\")"].
+  ["TMP=`printf \",{str,\\\"%s\\\"}\" ${", OutName,
+   "[@]}`\nTMP=${TMP:1}\necho \"", ?MSG, "#{\\\"", OutName, "\\\"=>[$TMP]}.\"\n"].
 
 preprocess( Script ) -> Script.
 

--- a/src/effi_interact.erl
+++ b/src/effi_interact.erl
@@ -58,20 +58,20 @@
 
 %% create_port/3
 %
-create_port( Lang, Script, Dir )
+create_port( Mod, Script, Dir )
 
-when is_atom( Lang ),
+when is_atom( Mod ),
      is_list( Script ),
      is_list( Dir ) ->
 
   % get interpreter
-  Interpreter = apply( Lang, interpreter, [] ),
+  Interpreter = apply( Mod, interpreter, [] ),
 
   % get prefix
-  Prefix = apply( Lang, prefix, [] ),
+  Prefix = apply( Mod, prefix, [] ),
 
   % get suffix
-  Suffix = apply( Lang, suffix, [] ),
+  Suffix = apply( Mod, suffix, [] ),
 
   % complement script
   ActScript = string:join( [Prefix, Script, Suffix, ""], "\n" ),

--- a/src/effi_perl.erl
+++ b/src/effi_perl.erl
@@ -19,7 +19,7 @@
 %% @author Jörgen Brandt <brandjoe@hu-berlin.de>
 
 
--module( python ).
+-module( effi_perl ).
 -author( "Jorgen Brandt <brandjoe@hu-berlin.de>" ).
 -vsn( "0.1.1-snapshot" ).
 
@@ -27,55 +27,35 @@
 
 -include( "effi.hrl" ).
 
-%% ------------------------------------------------------------
-%% Callback exports
-%% ------------------------------------------------------------
-
 -export( [ffi_type/0, assignment/3, dismissal/2, shebang/0, extension/0,
           preprocess/1, libpath/1, import/0] ).
 
 
-%% ------------------------------------------------------------
-%% Callback functions
-%% ------------------------------------------------------------
 
-%% ffi_type/0
-%
+libpath( _Path ) -> error( unsupported ).
 ffi_type() -> effi_script.
-
-
-%% shebang/0
-%
-shebang() -> "#!/usr/bin/env python".
-
-import() -> "import sys".
-
-preprocess( Script ) ->
-  "if True:\n "++re:replace( Script, "\\n", "\n ", [{return, list}, global] ).
-
-libpath( Path ) ->
-  ["sys.path.append(\"", Path, "\")"].
-
-%% extension/0
-%
-extension() -> ".py".
+shebang() -> "#!/usr/bin/env perl".
+import() -> "".
+preprocess( Script ) -> Script.
+extension() -> ".pl".
 
 %% assignment/3
 %
 assignment( ParamName, false, [Value] ) ->
-  [ParamName, $=, quote( Value ), $\n];
+  [$$, ParamName, $=, quote( Value ), ";\n"];
 
 assignment( ParamName, true, ValueList ) ->
-  [ParamName, "=[", string:join( [quote( Value ) || Value <- ValueList], "," ), "]\n"].
+  [$@, ParamName, "=(", string:join( [quote( Value ) || Value <- ValueList], "," ), ");\n"].
 
 
 %% dismissal/2
 %
 dismissal( OutName, false ) ->
-  ["print(\"", ?MSG, "#{\\\"", OutName, "\\\"=>", "[{str,\\\"\"+str(", OutName, ")+\"\\\"}]}.\\n\")\n"];
+  ["print \"", ?MSG, "#{\\\"", OutName, "\\\"=>[{str,\\\"$", OutName, "\\\"}]}.\\n\";\n"];
 
 dismissal( OutName, true ) ->
-  ["print(\"", ?MSG, "#{\\\"", OutName, "\\\"=>", "[\"+\",\".join(map(lambda x: \"{str,\\\"%s\\\"}\"%(x),", OutName, "))+\"]}.\\n\")\n"].
+  ["$TMP=join(\",\",map{\"{str,\\\"$_\\\"}\"}@", OutName, ");\n",
+   "print \"", ?MSG, "#{\\\"", OutName, "\\\"=>[$TMP]}.\\n\";\n"].
 
 
 %% ------------------------------------------------------------
@@ -84,4 +64,4 @@ dismissal( OutName, true ) ->
 
 %% quote/1
 %
-quote( S ) -> [$', S, $'].
+quote( S ) -> [$", S, $"].

--- a/src/effi_python.erl
+++ b/src/effi_python.erl
@@ -19,11 +19,11 @@
 %% @author Jörgen Brandt <brandjoe@hu-berlin.de>
 
 
--module( bash ).
+-module( effi_python ).
 -author( "Jorgen Brandt <brandjoe@hu-berlin.de>" ).
 -vsn( "0.1.1-snapshot" ).
 
--behaviour( effi_interact ).
+-behaviour( effi_script ).
 
 -include( "effi.hrl" ).
 
@@ -31,34 +31,34 @@
 %% Callback exports
 %% ------------------------------------------------------------
 
--export( [ffi_type/0, interpreter/0, prefix/0, suffix/0, assignment/3,
-          dismissal/2, preprocess/1, libpath/1] ).
+-export( [ffi_type/0, assignment/3, dismissal/2, shebang/0, extension/0,
+          preprocess/1, libpath/1, import/0] ).
 
 
 %% ------------------------------------------------------------
 %% Callback functions
 %% ------------------------------------------------------------
 
-libpath( _Path ) -> error( unsupported ).
-
 %% ffi_type/0
 %
-ffi_type() -> effi_interact.
+ffi_type() -> effi_script.
 
 
-%% interpreter/0
+%% shebang/0
 %
-interpreter() -> "bash".
+shebang() -> "#!/usr/bin/env python".
 
+import() -> "import sys".
 
-%% prefix/0
-prefix() -> "set -eu -o pipefail".
+preprocess( Script ) ->
+  "if True:\n "++re:replace( Script, "\\n", "\n ", [{return, list}, global] ).
 
+libpath( Path ) ->
+  ["sys.path.append(\"", Path, "\")"].
 
-%% suffix/0
+%% extension/0
 %
-suffix() -> "exit".
-
+extension() -> ".py".
 
 %% assignment/3
 %
@@ -66,19 +66,17 @@ assignment( ParamName, false, [Value] ) ->
   [ParamName, $=, quote( Value ), $\n];
 
 assignment( ParamName, true, ValueList ) ->
-  [ParamName, "=(", string:join( [quote( Value ) || Value <- ValueList], " " ), ")\n"].
+  [ParamName, "=[", string:join( [quote( Value ) || Value <- ValueList], "," ), "]\n"].
 
 
 %% dismissal/2
 %
 dismissal( OutName, false ) ->
-  ["echo \"", ?MSG, "#{\\\"", OutName, "\\\"=>[{str,\\\"$", OutName, "\\\"}]}.\"\n"];
+  ["print(\"", ?MSG, "#{\\\"", OutName, "\\\"=>", "[{str,\\\"\"+str(", OutName, ")+\"\\\"}]}.\\n\")\n"];
 
 dismissal( OutName, true ) ->
-  ["TMP=`printf \",{str,\\\"%s\\\"}\" ${", OutName,
-   "[@]}`\nTMP=${TMP:1}\necho \"", ?MSG, "#{\\\"", OutName, "\\\"=>[$TMP]}.\"\n"].
+  ["print(\"", ?MSG, "#{\\\"", OutName, "\\\"=>", "[\"+\",\".join(map(lambda x: \"{str,\\\"%s\\\"}\"%(x),", OutName, "))+\"]}.\\n\")\n"].
 
-preprocess( Script ) -> Script.
 
 %% ------------------------------------------------------------
 %% Internal functions
@@ -86,4 +84,4 @@ preprocess( Script ) -> Script.
 
 %% quote/1
 %
-quote( S ) -> [$", S, $"].
+quote( S ) -> [$', S, $'].


### PR DESCRIPTION
especially with [`erlport`](https://github.com/hdima/erlport/blob/3cc9775ab320ce53594ab3492db26ad98c6b528d/src/python.erl) which also defines a `python` module.
